### PR TITLE
Use absolute path for images

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,25 +1,25 @@
 # Welcome to the Stack-chan Community! 👋
 
-![stack-chan](/assets/images/stack_chan.jpg)
+![stack-chan](https://raw.githubusercontent.com/stack-chan/.github/main/assets/images/stack_chan.jpg)
 
 ## 🤖 Meet Stack-chan!
 
 Hello! Stack-chan is a palm-sized, super-kawaii open-source robot. Our motto is: "A communication robot, in your hands." Stack-chan combines the versatility of the "M5Stack" IoT module with the affectionate Japanese honorific "-chan." Being open-source is at our core, and Stack-chan invites creators and enthusiasts from around the world to participate in our vibrant community.
 
-![A communication robot, in your hands](/assets/images/in_your_hands.jpg)
+![A communication robot, in your hands](https://raw.githubusercontent.com/stack-chan/.github/main/assets/images/in_your_hands.jpg)
 
 ## 🌏 A Thriving Global Community
 
 Our community is active on platforms like Twitter and Discord, where daily interactions bring new innovations to Stack-chan’s development. Unlike traditional robot products managed by specific companies or individuals, we foster a decentralized environment where "everyone is both a developer and a user." We mainly operate in Japanese but with a growing international presence, we are also active in other languages. Join us on this journey!
 
-| ![maker faire shenzhen 1](/assets/images/mfshenzhen1.jpg) | ![maker faire shenzhen 2](/assets/images/mfshenzhen2.jpg) |
+| ![maker faire shenzhen 1](https://raw.githubusercontent.com/stack-chan/.github/main/assets/images/mfshenzhen1.jpg) | ![maker faire shenzhen 2](https://raw.githubusercontent.com/stack-chan/.github/main/assets/images/mfshenzhen2.jpg) |
 |:--------------:|:--------------:|
 
 ## 🚀 Stack-chan Activities
 
 Since its inception on July 2, 2021, Stack-chan has been celebrated through birthday parties, interactive events, and exhibitions at Tokyo Maker Faire, showcasing our collaborative spirit. More than 30 Stack-chan exhibits were presented at the Maker Faire, demonstrating our community's synergy. These events, including festive activities like Stack-chan themed cakes and piñatas, can be revisited through YouTube Live archives.
 
-![Stack-chan's birthday](/assets/images/stack_chan_birthday.jpg)
+![Stack-chan's birthday](https://raw.githubusercontent.com/stack-chan/.github/main/assets/images/stack_chan_birthday.jpg)
 
 ## 🌟 Join the Community
 


### PR DESCRIPTION
画像に相対パスを使う場合、organizationのプロフィールでの表示に失敗することがある。
解決策としてraw.githubusercontent.comのURLを直接使う。